### PR TITLE
#1feat: insert, update 기능 구현

### DIFF
--- a/todo/src/main/java/com/ssafy/todo/controller/TodoController.java
+++ b/todo/src/main/java/com/ssafy/todo/controller/TodoController.java
@@ -2,11 +2,7 @@ package com.ssafy.todo.controller;
 
 import com.ssafy.todo.dto.TodoGetDto;
 import com.ssafy.todo.service.TodoService;
-import com.ssafy.todo.service.TodoServiceImpl;
-import com.ssafy.todo.vo.Todo;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -35,5 +31,16 @@ public class TodoController {
         Map<String, List<TodoGetDto>> response = new HashMap<>();
         response.put("todos", todos);
         return response;
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteTodo(@PathVariable int id) {
+        service.deleteTodo(id);
+    }
+
+    @PostMapping
+    public void insertTodo(@RequestBody Map<String, String> todo) {
+        String content = todo.get("content");
+        service.insertTodo(content);
     }
 }

--- a/todo/src/main/java/com/ssafy/todo/controller/TodoController.java
+++ b/todo/src/main/java/com/ssafy/todo/controller/TodoController.java
@@ -22,10 +22,11 @@ public class TodoController {
     TodoService service;
 
     @GetMapping
-    public Map<String, List<TodoGetDto>> getTodos() {
+    public Map<String, Object> getTodos() {
         List<TodoGetDto> todos = service.getTodos();
-        Map<String, List<TodoGetDto>> response = new HashMap<>();
+        Map<String, Object> response = new HashMap<>();
+        response.put("message", "정상적으로 요청되었습니다.");
         response.put("todos", todos);
-        return response;
+        return response; //map -> json
     }
 }

--- a/todo/src/main/java/com/ssafy/todo/dto/TodoGetDto.java
+++ b/todo/src/main/java/com/ssafy/todo/dto/TodoGetDto.java
@@ -10,12 +10,14 @@ public class TodoGetDto {
     private int id;
     private String content;
     private boolean completed;
+    private String resName;
 
     public static TodoGetDto of(Todo todo) {
         TodoGetDto dto = new TodoGetDto();
         dto.setId(todo.getId());
         dto.setContent(todo.getContent());
         dto.setCompleted(todo.getCompleted());
+        dto.setResName("자원이름"); //vo와는 다른 속성 추가 가능
         return dto;
     }
 }

--- a/todo/src/main/java/com/ssafy/todo/repository/TodoRepository.java
+++ b/todo/src/main/java/com/ssafy/todo/repository/TodoRepository.java
@@ -1,12 +1,12 @@
 package com.ssafy.todo.repository;
 
-import com.ssafy.todo.dto.TodoGetDto;
 import com.ssafy.todo.vo.Todo;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 public interface TodoRepository {
 
     public List<Todo> getTodos();
+    void deleteTodo(int id);
+    void insertTodo(String content);
 }

--- a/todo/src/main/java/com/ssafy/todo/repository/TodoRepositoryImpl.java
+++ b/todo/src/main/java/com/ssafy/todo/repository/TodoRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.ssafy.todo.repository;
 
-import com.ssafy.todo.dto.TodoGetDto;
 import com.ssafy.todo.vo.Todo;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -18,5 +17,17 @@ public class TodoRepositoryImpl implements TodoRepository {
     public List<Todo> getTodos() {
         String query = "SELECT t FROM Todo t";
         return em.createQuery(query, Todo.class).getResultList();
+    }
+
+    @Override
+    public void deleteTodo(int id) {
+        String query = "DELETE FROM Todo t WHERE t.id = :id";
+        em.createQuery(query).setParameter("id", id).executeUpdate();
+    }
+
+    @Override
+    public void insertTodo(String content) {
+        String query = "INSERT INTO Todo (content) VALUES (:content)";
+        em.createQuery(query).setParameter("content", content).executeUpdate();
     }
 }

--- a/todo/src/main/java/com/ssafy/todo/service/TodoService.java
+++ b/todo/src/main/java/com/ssafy/todo/service/TodoService.java
@@ -1,7 +1,6 @@
 package com.ssafy.todo.service;
 
 import com.ssafy.todo.dto.TodoGetDto;
-import com.ssafy.todo.vo.Todo;
 
 import java.util.List;
 

--- a/todo/src/main/java/com/ssafy/todo/service/TodoServiceImpl.java
+++ b/todo/src/main/java/com/ssafy/todo/service/TodoServiceImpl.java
@@ -4,6 +4,7 @@ import com.ssafy.todo.dto.TodoGetDto;
 import com.ssafy.todo.repository.TodoRepository;
 import com.ssafy.todo.repository.TodoRepositoryImpl;
 import com.ssafy.todo.vo.Todo;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@Slf4j
 public class TodoServiceImpl implements TodoService{
 
     @Autowired
@@ -19,9 +21,11 @@ public class TodoServiceImpl implements TodoService{
     @Override
     public List<TodoGetDto> getTodos() {
         List<Todo> todos = repository.getTodos();
+        //log.info("log");
         return todos.stream()
                 .map(TodoGetDto::of)
                 .collect(Collectors.toList());
+        // List<Todo>를 List<TodoGetDto>로 변환
     }
 
     @Override

--- a/todo/src/main/java/com/ssafy/todo/service/TodoServiceImpl.java
+++ b/todo/src/main/java/com/ssafy/todo/service/TodoServiceImpl.java
@@ -3,17 +3,19 @@ package com.ssafy.todo.service;
 import com.ssafy.todo.dto.TodoGetDto;
 import com.ssafy.todo.repository.TodoQuerydslRepository;
 import com.ssafy.todo.repository.TodoRepository;
-import com.ssafy.todo.repository.TodoRepositoryImpl;
 import com.ssafy.todo.vo.Todo;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 @Slf4j
+@Transactional(readOnly = true)
 public class TodoServiceImpl implements TodoService{
 
     @Autowired
@@ -29,7 +31,6 @@ public class TodoServiceImpl implements TodoService{
         return todos.stream()
                 .map(TodoGetDto::of)
                 .collect(Collectors.toList());
-        // List<Todo>를 List<TodoGetDto>로 변환
     }
 
     @Override
@@ -41,17 +42,20 @@ public class TodoServiceImpl implements TodoService{
     }
 
     @Override
+    @Transactional
     public void deleteTodo(int id) {
-
+        repository.deleteTodo(id);
     }
 
     @Override
+    @Transactional
     public void updateTodo(int id) {
 
     }
 
     @Override
+    @Transactional
     public void insertTodo(String content) {
-
+        repository.insertTodo(content);
     }
 }

--- a/todo/src/main/java/com/ssafy/todo/vo/Todo.java
+++ b/todo/src/main/java/com/ssafy/todo/vo/Todo.java
@@ -1,6 +1,8 @@
 package com.ssafy.todo.vo;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.Getter;
 import lombok.Setter;
@@ -10,6 +12,7 @@ import lombok.Setter;
 public class Todo {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     int id;
 
     String content;

--- a/todo/src/main/resources/application.yml
+++ b/todo/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-#      ddl-auto: create
+#      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
## 🔥 Related Issues
resolved #1

## 💜 작업 내용
- [x] ~ delete 기능 구현
- [x] ~ insert 기능 구현

## ✅ PR Point
- CRUD의 CD를 구현했습니다.
- 트랜잭션 어노테이션을 추가했습니다.
- 트랜잭션은 서비스 계층에서 관리합니다.
- ServiceImpl 위에는 `@Transactional(readOnly = true)` 으로 관리하고 데이터의 변경이 일어나는 insert, update, delete에 `@Transactional`을 작성했습니다.

## 😡 Trouble Shooting
### DELETE 이슈
- 에러: `Result type given for a non-SELECT Query`
- 해결: EntityManager을 사용할 때, 반환할 타입이 명확한 경우만 createQuery()의 두번째 파라미터를 지정해야 한다.
- 이유: 쿼리 객체는 TypeQuery와 Query가 있는데, 조회 대상이 명확하여 반환 타입이 있는 SELECT의 경우 `em.createQuery(query, Todo.class).getResultList();`로 TypeQuery를 사용하지만, DELETE나 INSERT의 경우 반환 타입이 명확하지 않아 Query 객체로 받아야 한다. 즉 `em.createQuery(query).executeUpdate();`으로 작성해야 한다.

### INSERT 이슈
- 에러: `Error accessing field [int com.ssafy.todo.vo.Todo.id] by reflection for persistent property [com.ssafy.todo.vo.Todo#id] : null] with root cause`
- 해결: id 속성에 `@GeneratedValue(strategy = GenerationType.IDENTITY)`를 추가한다.
- 이유: Todo 클래스의 id는 auto increment로 지정되어 있기 때문에 insert를 할 때 특별한 어노테이션을 추가해줘야 한다.

- 에러: default false 설정이 제대로 동작하지 않음
- 해결: DB 설정을 다시 확인하는 습관을 들이자.

- 에러: JSON 데이터를 POST로 받을 때
- 해결: Key-Value 값으로 넘어오는 거니깐 Map을 사용하자!

## 참고 링크
- https://velog.io/@gkdud583/JPA-GeneratedValue-AUTO%EC%99%80-IDENTITY-%EC%B0%A8%EC%9D%B4%EC%A0%90
- https://cornswrold.tistory.com/334#google_vignette
- https://velog.io/@uiurihappy/Spring-boot-TransactionalreadOnly-true%EB%8A%94-%EC%99%9C-%EB%B6%99%EC%97%AC%EC%95%BC-%ED%95%A0%EA%B9%8C