### PR TITLE
#2refactor: ToCreateDto 사용 및 @Builder 사용, Refactoring

### DIFF
--- a/todo/src/main/generated/com/ssafy/todo/vo/QTodo.java
+++ b/todo/src/main/generated/com/ssafy/todo/vo/QTodo.java
@@ -1,0 +1,41 @@
+package com.ssafy.todo.vo;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QTodo is a Querydsl query type for Todo
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QTodo extends EntityPathBase<Todo> {
+
+    private static final long serialVersionUID = 204195706L;
+
+    public static final QTodo todo = new QTodo("todo");
+
+    public final BooleanPath completed = createBoolean("completed");
+
+    public final StringPath content = createString("content");
+
+    public final NumberPath<Integer> id = createNumber("id", Integer.class);
+
+    public QTodo(String variable) {
+        super(Todo.class, forVariable(variable));
+    }
+
+    public QTodo(Path<? extends Todo> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QTodo(PathMetadata metadata) {
+        super(Todo.class, metadata);
+    }
+
+}
+

--- a/todo/src/main/java/com/ssafy/todo/controller/TodoController.java
+++ b/todo/src/main/java/com/ssafy/todo/controller/TodoController.java
@@ -1,5 +1,6 @@
 package com.ssafy.todo.controller;
 
+import com.ssafy.todo.dto.TodoCreateDto;
 import com.ssafy.todo.dto.TodoGetDto;
 import com.ssafy.todo.service.TodoService;
 import com.ssafy.todo.util.ResponseUtil;
@@ -50,9 +51,8 @@ public class TodoController {
     }
 
     @PostMapping
-    public ResponseEntity<String> insertTodo(@RequestBody Map<String, String> todo) {
-        String content = todo.get("content");
-        long id = service.insertTodo(content);
+    public ResponseEntity<String> insertTodo(@RequestBody TodoCreateDto dto) {
+        long id = service.insertTodo(dto.getContent());
         return ResponseUtil.createBooleanResponse(id > 0, id + "의 todo가 생성되었습니다.");
     }
 

--- a/todo/src/main/java/com/ssafy/todo/dto/TodoGetDto.java
+++ b/todo/src/main/java/com/ssafy/todo/dto/TodoGetDto.java
@@ -1,21 +1,41 @@
 package com.ssafy.todo.dto;
 
 import com.ssafy.todo.vo.Todo;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class TodoGetDto {
     private int id;
     private String content;
     private boolean completed;
 
-    public static TodoGetDto of(Todo todo) {
-        TodoGetDto dto = new TodoGetDto();
-        dto.setId(todo.getId());
-        dto.setContent(todo.getContent());
-        dto.setCompleted(todo.getCompleted());
-        return dto;
-    }
+    /*
+    - of 메소드
+    : of 메소드는 보통 정적(static) 메소드로 구현되며, 여러 개의 인자를 받아 DTO 객체를 생성하는 역할.
+    주로 생성자에 필요한 인자들을 파라미터로 받아서 DTO 객체를 생성하는 용도로 사용.
+
+    - from 메소드
+    : from 메소드는 보통 정적 메소드로 구현되며, 다른 객체를 기반으로 DTO를 생성하는 역할.
+    주로 엔티티나 다른 DTO를 변환하여 현재 DTO로 매핑하는 용도로 사용.
+     */
+//    public static TodoGetDto from(Todo todo) {
+//        TodoGetDto dto = new TodoGetDto();
+//        dto.setId(todo.getId());
+//        dto.setContent(todo.getContent());
+//        dto.setCompleted(todo.getCompleted());
+//        return dto;
+//    }
+
+//    // builder() 사용
+//    public static TodoGetDto from(Todo todo){
+//        return TodoGetDto.builder()
+//                .id(todo.getId())
+//                .content(todo.getContent())
+//                .completed(todo.getCompleted())
+//                .build();
+//    }
 }

--- a/todo/src/main/java/com/ssafy/todo/service/TodoServiceImpl.java
+++ b/todo/src/main/java/com/ssafy/todo/service/TodoServiceImpl.java
@@ -25,16 +25,18 @@ public class TodoServiceImpl implements TodoService{
     @Override
     public List<TodoGetDto> getTodos() {
         List<Todo> todos = repository.findAll();
-        return todos.stream()
-                .map(TodoGetDto::of)
-                .collect(Collectors.toList());
+        return todos.stream().map(todo -> TodoGetDto.builder()
+                .id(todo.getId())
+                .content(todo.getContent())
+                .completed(todo.getCompleted())
+                .build()).collect(Collectors.toList());
     }
 
 //    @Override
 //    public List<TodoGetDto> getTodosWithQuerydsl() {
 //        List<Todo> todos = repository.getTodosWithQuerydsl();
 //        return todos.stream()
-//                .map(TodoGetDto::of)
+//                .map(TodoGetDto::from)
 //                .collect(Collectors.toList());
 //    }
 
@@ -64,9 +66,13 @@ public class TodoServiceImpl implements TodoService{
     @Override
     @Transactional
     public long insertTodo(String content) {
-        Todo todo = new Todo();
-        todo.setContent(content);
-        repository.save(todo);
-        return todo.getId();
+        Todo todo = Todo.builder()
+                .content(content)
+                .build();
+
+        Todo savedTodo = repository.save(todo);
+        return savedTodo.getId();
+
     }
+
 }

--- a/todo/src/main/java/com/ssafy/todo/vo/Todo.java
+++ b/todo/src/main/java/com/ssafy/todo/vo/Todo.java
@@ -1,13 +1,15 @@
 package com.ssafy.todo.vo;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 
 @Entity
 @Getter @Setter
 @DynamicInsert
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Todo {
 
     @Id


### PR DESCRIPTION
## 🔥 Related Issues
resolved #2

## 💜 작업 내용
- [x] ~ Insert시 @RequestBody로 Dto 사용
- [x] ~ from 메서드 선언하지 말고 @Builder 사용
- [x] ~ 전체적인 코드 Refactoring

## ✅ PR Point
- @Builder를 사용하고 코드를 Refactoring 했습니다.
- 생성해놓고 사용하지 않았던 TodoCreateDto를 사용하였습니다.

### @Builder 사용하기
- 기존의 dto에 from 메서드를 정의해두고 사용하던 방식에서 @Builder 어노테이션을 사용하였습니다.
- 지금은 생성자의 인자가 몇개 없어서 편한대로 사용하면 되지만 나중에 생성자에서 인자가 많을 때를 고려하여 빌더 패턴 사용
- Builder 패턴을 사용하면 
  - 불필요한 생성자 제거
  - 데이터 순서에 상관 없이 객체 생성 가능
  - 명시적 선언으로 이해가 쉬움
  - 각 인자가 어떤 의미인지 알기 쉬움
등과 같은 장점 존재.

### TodoCreateDto 사용
- 기존에 생성해놓고 사용하지 않았던 Dto 사용
- Controller에서 Post를 통해 content를 입력 받을 때 @RequestBody로 Dto를 넘겨줌

"더 자세한 설명은 Notion에 정리"
## 😡 Trouble Shooting
- `lombok`의 `@Builder`를 사용할 때 "needs a proper constructor for this class" 오류가 발생

1. **인자가 있는 생성자 부재**: `@Builder`는 객체를 생성하기 위해 모든 필드를 포함하는 인자가 있는 생성자를 필요로 한다. 이 경우 `@AllArgsConstructor`를 추가해주어야 한다.
2. **기본 생성자 부재**: 어떤 프레임워크(예: JPA, Jackson 등)는 기본 생성자를 요구함. 이 경우 `@NoArgsConstructor`를 추가해야 한다.

## 📚 Reference
- https://esoongan.tistory.com/82
- Chatgpt
