### PR TITLE
#2feat: Paging 처리 위한 article Post 기능 추가(초기 세팅)

### DIFF
--- a/todo/src/main/java/com/ssafy/sandbox/paging/controller/PagingController.java
+++ b/todo/src/main/java/com/ssafy/sandbox/paging/controller/PagingController.java
@@ -1,14 +1,14 @@
 package com.ssafy.sandbox.paging.controller;
 
+import com.ssafy.sandbox.paging.dto.ArticlePageDto;
 import com.ssafy.sandbox.paging.service.PagingService;
 import com.ssafy.sandbox.paging.vo.Article;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/articles")
@@ -18,12 +18,27 @@ public class PagingController {
 
     private final PagingService pagingService;
 
+    @GetMapping("/paging/offset")
+    public ResponseEntity<?> getArticlesByOffset(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        ArticlePageDto articlePage = pagingService.getArticlesByOffset(page-1, size);
+        return ResponseEntity.ok(articlePage);
+    }
+
+//    @PostMapping("/make")
+//    public ResponseEntity<?> postArticles(){
+//        String url = "https://jsonplaceholder.typicode.com/todos";
+//        ResponseEntity<Article[]> articles = new RestTemplate().getForEntity(url, Article[].class);
+//        pagingService.saveArticles(articles);
+//        return ResponseEntity.ok(articles);
+//    }
+
     @PostMapping("/make")
-    public ResponseEntity<?> postArticles(){
-        String url = "https://jsonplaceholder.typicode.com/todos";
-        ResponseEntity<Article[]> articles = new RestTemplate().getForEntity(url, Article[].class);
+    public ResponseEntity<String> makeArticle(@RequestBody Map<String, List<Article>> request) {
+        List<Article> articles = request.get("articles");
         pagingService.saveArticles(articles);
-        return ResponseEntity.ok(articles);
+        return ResponseEntity.ok("Success");
     }
 
 }

--- a/todo/src/main/java/com/ssafy/sandbox/paging/controller/PagingController.java
+++ b/todo/src/main/java/com/ssafy/sandbox/paging/controller/PagingController.java
@@ -1,0 +1,29 @@
+package com.ssafy.sandbox.paging.controller;
+
+import com.ssafy.sandbox.paging.service.PagingService;
+import com.ssafy.sandbox.paging.vo.Article;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+@RestController
+@RequestMapping("/articles")
+@RequiredArgsConstructor
+@CrossOrigin(origins = "*", allowedHeaders = "*")
+public class PagingController {
+
+    private final PagingService pagingService;
+
+    @PostMapping("/make")
+    public ResponseEntity<?> postArticles(){
+        String url = "https://jsonplaceholder.typicode.com/todos";
+        ResponseEntity<Article[]> articles = new RestTemplate().getForEntity(url, Article[].class);
+        pagingService.saveArticles(articles);
+        return ResponseEntity.ok(articles);
+    }
+
+}

--- a/todo/src/main/java/com/ssafy/sandbox/paging/dto/ArticlePageDto.java
+++ b/todo/src/main/java/com/ssafy/sandbox/paging/dto/ArticlePageDto.java
@@ -1,0 +1,14 @@
+package com.ssafy.sandbox.paging.dto;
+
+import com.ssafy.sandbox.paging.vo.Article;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class ArticlePageDto {
+    private int totalPage;
+    private List<Article> articles;
+}

--- a/todo/src/main/java/com/ssafy/sandbox/paging/repository/PagingRepository.java
+++ b/todo/src/main/java/com/ssafy/sandbox/paging/repository/PagingRepository.java
@@ -1,0 +1,7 @@
+package com.ssafy.sandbox.paging.repository;
+
+import com.ssafy.sandbox.paging.vo.Article;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PagingRepository extends JpaRepository<Article, Integer> {
+}

--- a/todo/src/main/java/com/ssafy/sandbox/paging/service/PagingService.java
+++ b/todo/src/main/java/com/ssafy/sandbox/paging/service/PagingService.java
@@ -1,8 +1,13 @@
 package com.ssafy.sandbox.paging.service;
 
+import com.ssafy.sandbox.paging.dto.ArticlePageDto;
 import com.ssafy.sandbox.paging.vo.Article;
-import org.springframework.http.ResponseEntity;
+
+import java.util.List;
 
 public interface PagingService {
-    void saveArticles(ResponseEntity<Article[]> articles);
+
+    ArticlePageDto getArticlesByOffset(int page, int size);
+//    void saveArticles(ResponseEntity<Article[]> articles);
+    void saveArticles(List<Article> articles);
 }

--- a/todo/src/main/java/com/ssafy/sandbox/paging/service/PagingService.java
+++ b/todo/src/main/java/com/ssafy/sandbox/paging/service/PagingService.java
@@ -1,0 +1,8 @@
+package com.ssafy.sandbox.paging.service;
+
+import com.ssafy.sandbox.paging.vo.Article;
+import org.springframework.http.ResponseEntity;
+
+public interface PagingService {
+    void saveArticles(ResponseEntity<Article[]> articles);
+}

--- a/todo/src/main/java/com/ssafy/sandbox/paging/service/PagingServiceImpl.java
+++ b/todo/src/main/java/com/ssafy/sandbox/paging/service/PagingServiceImpl.java
@@ -1,15 +1,16 @@
 package com.ssafy.sandbox.paging.service;
 
+import com.ssafy.sandbox.paging.dto.ArticlePageDto;
 import com.ssafy.sandbox.paging.repository.PagingRepository;
 import com.ssafy.sandbox.paging.vo.Article;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -18,14 +19,31 @@ public class PagingServiceImpl implements PagingService {
 
     private final PagingRepository pagingRepository;
 
+    @Override
+    public ArticlePageDto getArticlesByOffset(int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("id").ascending());
+        Page<Article> articlePage = pagingRepository.findAll(pageRequest);
+
+        List<Article> articles = articlePage.getContent();
+        int totalPages = articlePage.getTotalPages();
+
+        return new ArticlePageDto(totalPages, articles);
+    }
+
+//    @Transactional
+//    @Override
+//    public void saveArticles(ResponseEntity<Article[]> articles) {
+//        List<Article> articleList = new ArrayList<>();
+//        for (Article article : Objects.requireNonNull(articles.getBody())) {
+//            articleList.add(Article.builder().id(article.getId()).userId(article.getUserId()).title(article.getTitle()).completed(article.getCompleted()).build());
+//        }
+//        pagingRepository.saveAll(articleList);
+//
+//    }
+
     @Transactional
     @Override
-    public void saveArticles(ResponseEntity<Article[]> articles) {
-        List<Article> articleList = new ArrayList<>();
-        for (Article article : Objects.requireNonNull(articles.getBody())) {
-            articleList.add(Article.builder().id(article.getId()).userId(article.getUserId()).title(article.getTitle()).completed(article.getCompleted()).build());
-        }
-        pagingRepository.saveAll(articleList);
-
+    public void saveArticles(List<Article> articles) {
+        pagingRepository.saveAll(articles);
     }
 }

--- a/todo/src/main/java/com/ssafy/sandbox/paging/service/PagingServiceImpl.java
+++ b/todo/src/main/java/com/ssafy/sandbox/paging/service/PagingServiceImpl.java
@@ -1,0 +1,31 @@
+package com.ssafy.sandbox.paging.service;
+
+import com.ssafy.sandbox.paging.repository.PagingRepository;
+import com.ssafy.sandbox.paging.vo.Article;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PagingServiceImpl implements PagingService {
+
+    private final PagingRepository pagingRepository;
+
+    @Transactional
+    @Override
+    public void saveArticles(ResponseEntity<Article[]> articles) {
+        List<Article> articleList = new ArrayList<>();
+        for (Article article : Objects.requireNonNull(articles.getBody())) {
+            articleList.add(Article.builder().id(article.getId()).userId(article.getUserId()).title(article.getTitle()).completed(article.getCompleted()).build());
+        }
+        pagingRepository.saveAll(articleList);
+
+    }
+}

--- a/todo/src/main/java/com/ssafy/sandbox/paging/vo/Article.java
+++ b/todo/src/main/java/com/ssafy/sandbox/paging/vo/Article.java
@@ -1,8 +1,12 @@
 package com.ssafy.sandbox.paging.vo;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.*;
+
+import java.util.Date;
 
 @Entity
 @Getter @Setter
@@ -11,11 +15,12 @@ import lombok.*;
 @AllArgsConstructor
 public class Article {
 
-    @Id
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
-    private int userId;
+//    private int userId;
 
     private String title;
-    private Boolean completed;
+//    private Boolean completed;
+    private Date createdAt;
 
 }

--- a/todo/src/main/java/com/ssafy/sandbox/paging/vo/Article.java
+++ b/todo/src/main/java/com/ssafy/sandbox/paging/vo/Article.java
@@ -1,0 +1,21 @@
+package com.ssafy.sandbox.paging.vo;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Entity
+@Getter @Setter
+@RequiredArgsConstructor
+@Builder
+@AllArgsConstructor
+public class Article {
+
+    @Id
+    private int id;
+    private int userId;
+
+    private String title;
+    private Boolean completed;
+
+}

--- a/todo/src/main/resources/application.yml
+++ b/todo/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-#      ddl-auto: update
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
## 🔥 Related Issues
resolved #2

## 💜 작업 내용
- [x] Paging 처리를 위한 초기 세팅
  - Sandbox에서 url로 준 Json을 받아 DB에 저장

## ✅ PR Point
- URL로 주어진 Article에 대한 Json 정보를 DB에 저장하는 기능 구현

- Controller, Repository, Service 코드 작성
  - PagingController: /articles/make 엔드포인트에 대한 응답으로 JSON 데이터를 받아와 저장하는 기능
  - PagingService: 비즈니스 로직을 담당하며, 받은 데이터를 repository에 저장
  - PagingRepository: 데이터베이스와 연결하여 데이터 저장을 처리
    
## 😡 Trouble Shooting
- 문제: 처음에 JSON 데이터를 단일 Article 객체로 받으려 했지만, API는 여러 Article 항목을 포함한 배열 형태의 JSON 데이터를 반환. 이를 단일 Article 객체로 파싱하려다 보니 구조가 일치하지 않아 역직렬화 오류가 발생.

- 해결 방법: 코드를 수정하여 JSON 응답을 Article[] 배열 형태로 받도록 변경. ResponseEntity<Article[]>를 사용하여 API에서 반환된 JSON 데이터를 Article 객체 배열로 매핑. 이를 통해 배열 내 각 Article 항목을 순회하며 데이터베이스에 개별적으로 저장.

## 📚 Reference
- https://sasca37.tistory.com/270



# #2feat: Paging Article 생성 및 Offset 기능 구현

## 🔥 Related Issues
resolved #2

## 💜 작업 내용
- [x] API 명세와 맞지 않은 데이터 추가 기능 수정
- [x] Offset 방식을 활용한 Pagination 구현

## ✅ PR Point
1. **API 명세와 맞지 않은 데이터 추가 기능 수정**
    - API 명세와 일치하지 않는 데이터가 추가될 경우 발생한 에러를 해결
      기존의 데이터 추가 로직을 수정하여, 프론트에서 전송한 데이터를 `@RequestBody`로 받아 처리하도록 변경

2. **Offset 기반 Pagination 구현**
    - 대량의 데이터를 처리하기 위해 **Offset 방식의 Pagination**을 추가
    - `page`와 `size` 파라미터를 사용해 페이지 번호와 한 페이지당 데이터 수를 조정할 수 있음
    - 클라이언트가 `page`와 `size` 값을 지정하여 필요한 범위의 데이터만 가져올 수 있도록 하여, 서버와 클라이언트의 리소스를 효율적으로 사용할 수 있게 함
    - `@RequestParam`을 통해 Default로 `page=1`, `size=10`을 설정했으며, 해당 값은 필요에 따라 변경할 수 있음.
    - `PageRequest` 객체를 사용하여 데이터 조회 시 **오름차순 정렬**을 지정했으며, 총 페이지 수와 같은 메타데이터도 포함하도록 설계

## 😡 Trouble Shooting
### 1. 데이터 추가 기능에서 API 명세와 맞지 않는 데이터 처리
- **설명**: 프론트엔드에서 데이터를 전송하는 형식을 고려하지 않고, 백엔드에서 직접 URL에 접근하여 데이터를 가져오는 방식으로 구현. 이로 인해 프론트엔드에서 전송된 데이터와 API 명세 간 불일치가 발생하여, 데이터 추가 기능에 문제가 생김

### 원인 분석
- 데이터 전송 방식과 데이터 구조에 대한 프론트엔드와 백엔드 간의 명확한 합의가 없었기 때문에, 백엔드에서 프론트엔드가 제공하는 데이터 형식을 제대로 반영하지 않고 URL에 직접 접근해 데이터를 가져오도록 구현했음.
- 이로 인해 API 명세와 맞지 않는 데이터가 수신되어, 서버에서 데이터 처리 과정에서 오류가 발생

### 해결 방법
- **데이터 전송 방식 재구성**: 프론트엔드에서 데이터를 올바른 형식으로 전송하도록 수정하고, 백엔드에서는 `@RequestBody`를 사용해 프론트엔드에서 전송된 데이터를 직접 받아 처리하도록 변경.

### 2. Pagination에서 첫 페이지가 아닌 두 번째 페이지부터 출력되는 문제
- **설명**: Pagination 기능 구현 시 첫 페이지가 1번부터 시작되지 않고, 2페이지부터 출력되는 문제가 발생. 한 페이지에 6개씩 출력되도록 설정했지만, 1페이지에 7번째 항목이 포함되어 출력 순서가 어긋나는 상황이 나타남.

### 원인 분석
- `offset` 값을 잘못 설정하여, 1페이지에서도 `offset`이 1로 적용되었음. 이로 인해 데이터 조회가 첫 항목이 아닌 두 번째 항목부터 시작되어, 1페이지의 첫 번째 데이터로 7번째 항목이 출력됨

### 해결 방법
- **Offset 값 수정**: Default Value를 1로 설정하고 페이지 계산 시 page - 1로 계산하여, 데이터가 정확히 첫 항목부터 조회되도록 수정. 이를 통해 1페이지가 올바른 순서로 출력되도록 수정


## 📚 Reference
- https://velog.io/@conatuseus/JPA-Paging-%ED%8E%98%EC%9D%B4%EC%A7%80-%EB%82%98%EB%88%84%EA%B8%B0-o7jze1wqhj
- https://betterdev.tistory.com/17
- https://digitalbourgeois.tistory.com/120
- https://velog.io/@songyuheon/Spring-Data-JPA%EC%9D%98-Page-%EA%B0%9D%EC%B2%B4

