### PR TITLE
#2feat: Paging Cursor 방식 구현

### DIFF
--- a/todo/src/main/java/com/ssafy/sandbox/paging/controller/PagingController.java
+++ b/todo/src/main/java/com/ssafy/sandbox/paging/controller/PagingController.java
@@ -1,6 +1,7 @@
 package com.ssafy.sandbox.paging.controller;
 
-import com.ssafy.sandbox.paging.dto.ArticlePageDto;
+import com.ssafy.sandbox.paging.dto.ArticlePageCursorDto;
+import com.ssafy.sandbox.paging.dto.ArticlePageOffsetDto;
 import com.ssafy.sandbox.paging.service.PagingService;
 import com.ssafy.sandbox.paging.vo.Article;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,15 @@ public class PagingController {
     public ResponseEntity<?> getArticlesByOffset(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size) {
-        ArticlePageDto articlePage = pagingService.getArticlesByOffset(page-1, size);
+        ArticlePageOffsetDto articlePage = pagingService.getArticlesByOffset(page-1, size);
+        return ResponseEntity.ok(articlePage);
+    }
+
+    @GetMapping("/paging/cursor")
+    public ResponseEntity<?> getArticlesByCursor(
+            @RequestParam("size") int size,
+            @RequestParam("cursorId") int cursorId){
+        ArticlePageCursorDto articlePage = pagingService.getArticleByCursor(size, cursorId);
         return ResponseEntity.ok(articlePage);
     }
 

--- a/todo/src/main/java/com/ssafy/sandbox/paging/dto/ArticlePageCursorDto.java
+++ b/todo/src/main/java/com/ssafy/sandbox/paging/dto/ArticlePageCursorDto.java
@@ -1,0 +1,18 @@
+package com.ssafy.sandbox.paging.dto;
+
+import com.ssafy.sandbox.paging.vo.Article;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class ArticlePageCursorDto {
+    private Integer lastId;
+    private List<Article> articles;
+
+    public ArticlePageCursorDto(List<Article> articles) {
+        this.articles = articles;
+    }
+}

--- a/todo/src/main/java/com/ssafy/sandbox/paging/dto/ArticlePageOffsetDto.java
+++ b/todo/src/main/java/com/ssafy/sandbox/paging/dto/ArticlePageOffsetDto.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Data
 @AllArgsConstructor
-public class ArticlePageDto {
+public class ArticlePageOffsetDto {
     private int totalPage;
     private List<Article> articles;
 }

--- a/todo/src/main/java/com/ssafy/sandbox/paging/repository/PagingRepository.java
+++ b/todo/src/main/java/com/ssafy/sandbox/paging/repository/PagingRepository.java
@@ -1,7 +1,13 @@
 package com.ssafy.sandbox.paging.repository;
 
 import com.ssafy.sandbox.paging.vo.Article;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface PagingRepository extends JpaRepository<Article, Integer> {
+    Page<Article> findByIdGreaterThan(int cursorId, PageRequest pageRequest);
 }

--- a/todo/src/main/java/com/ssafy/sandbox/paging/service/PagingService.java
+++ b/todo/src/main/java/com/ssafy/sandbox/paging/service/PagingService.java
@@ -1,13 +1,16 @@
 package com.ssafy.sandbox.paging.service;
 
-import com.ssafy.sandbox.paging.dto.ArticlePageDto;
+import com.ssafy.sandbox.paging.dto.ArticlePageCursorDto;
+import com.ssafy.sandbox.paging.dto.ArticlePageOffsetDto;
 import com.ssafy.sandbox.paging.vo.Article;
 
 import java.util.List;
 
 public interface PagingService {
 
-    ArticlePageDto getArticlesByOffset(int page, int size);
+    ArticlePageOffsetDto getArticlesByOffset(int page, int size);
+    ArticlePageCursorDto getArticleByCursor(int size, int cursorId);
 //    void saveArticles(ResponseEntity<Article[]> articles);
     void saveArticles(List<Article> articles);
+
 }

--- a/todo/src/main/java/com/ssafy/sandbox/paging/vo/Article.java
+++ b/todo/src/main/java/com/ssafy/sandbox/paging/vo/Article.java
@@ -17,10 +17,8 @@ public class Article {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
-//    private int userId;
 
     private String title;
-//    private Boolean completed;
     private Date createdAt;
 
 }


### PR DESCRIPTION
## 🔥 Related Issues
resolved #2 

## 💜 작업 내용
- [x] ~ Paging Cursor 방식 구현

## ✅ PR Point
- 커서 방식의 구현은 원하는 데이터가 어떤 데이터의 다음에 있는지로 페이징을 구현하기 때문에 offset에 비해 성능 문제가 적다.
- 그래서 가장 마지막 row id 값을 받아 그 다음 id를 찾아오는 방식으로 구현했다.
- 커서 기반 페이징을 위해서는 반드시 정렬 기준이 되는 필드 중 적어도 하나는 고유값이어야 한다.
- 지금 프로젝트는 Article이 id값으로 정렬되어 있으므로 id를 기준으로 row를 검색하여 그 다음 id 값을 가지는 행을 size만큼 불러온다.
- Spring Data JPA를 사용하면 잘 작성한 함수명대로 SQL을 자동 생성해준다.

### 구현
- 커서 방식을 위한 Dto 선언
- 컨트롤러 getArticlesByCursor 함수
- 서비스 getArticleByCursor 함수
- Repository에는 Spring Data JPA를 사용하기 위한 dummy 함수명을 선언했다.

## 😡 Trouble Shooting
- 가장 마지막에 도달했을 때, response로 빈 객체를 넘겨주어야 하기 때문에 DTO에 articles만 받는 생성자를 만들었다.
- 그러면 lastId에는 null이 자동으로 넘겨진다. (undefined를 하고 싶었는데 이건 명세 상 오류인듯!)

## 📚 Reference
- https://velog.io/@minsangk/%EC%BB%A4%EC%84%9C-%EA%B8%B0%EB%B0%98-%ED%8E%98%EC%9D%B4%EC%A7%80%EB%84%A4%EC%9D%B4%EC%85%98-Cursor-based-Pagination-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0
